### PR TITLE
error when building other apps

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 /node_modules/
+/src/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ibm-shopping-list-model",
   "version": "0.3.1",
   "description": "Domain model implementation for the Shopping List series of Offline First demo apps.",
-  "main": "./src/index.js",
+  "main": "./dist/bundle.js",
   "scripts": {
     "test-mocha": "mocha",
     "test-karma": "karma start --single-run --browsers ChromeHeadless",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
   output: {
     filename: "bundle.js",
     path: path.resolve(__dirname, "dist"),
-    library: "ShoppingListModel"
+    library: "ShoppingListModel",
+    libraryTarget: 'umd',
+    umdNamedDefine: true
   },
   module: {
     loaders: [


### PR DESCRIPTION
other apps that have a dependency on this module fail to build because
es6 code is included in node_modules. in addition, the bundled output does
not export anything